### PR TITLE
Division Hub

### DIFF
--- a/src/pages/divisions.js
+++ b/src/pages/divisions.js
@@ -17,8 +17,26 @@ function list(templates, division, req, res) {
 function nav(templates, season, division, req, res) {
   var division_id = req.params.division_id
   division.getDivision(division_id).then(division => {
-    return season.getSeasons().then(seasons => {
+    return season.getActiveSeason().then(seasons => {
       var html = templates.division.division({
+        user: req.user,
+        division: division,
+        seasons: seasons
+      })
+
+      res.send(html)
+    })
+  }).catch(err => {
+    console.error(err)
+    res.sendStatus(500)
+  })
+}
+
+function all_seasons(templates, season, division, req, res) {
+  var division_id = req.params.division_id
+  division.getDivision(division_id).then(division => {
+    return season.getSeasons().then(seasons => {
+      var html = templates.division.all_seasons({
         user: req.user,
         division: division,
         seasons: seasons
@@ -110,6 +128,10 @@ module.exports = (templates, season, division) => {
     nav: {
       route: '/divisions/:division_id',
       handler: nav.bind(null, templates, season, division)
+    },
+    all_seasons: {
+      route: '/divisions/:division_id/all_seasons',
+      handler: all_seasons.bind(null, templates, season, division)
     },
     create: {
       route: '/divisions/create',

--- a/src/repos/division.js
+++ b/src/repos/division.js
@@ -33,7 +33,9 @@ function getDivision(db, id) {
   SELECT
     division.id,
     division.name,
-    division.active
+    division.active,
+    division.start_time,
+    division.discord_url
   FROM
     division
   WHERE

--- a/src/repos/division.js
+++ b/src/repos/division.js
@@ -33,9 +33,7 @@ function getDivision(db, id) {
   SELECT
     division.id,
     division.name,
-    division.active,
-    division.start_time,
-    division.discord_url
+    division.active
   FROM
     division
   WHERE

--- a/src/server.js
+++ b/src/server.js
@@ -137,6 +137,7 @@ app.get(divisionPages.list.route, divisionPages.list.handler)
 app.get(divisionPages.create.route, divisionPages.create.handler)
 app.get(divisionPages.edit.route, divisionPages.edit.handler)
 app.get(divisionPages.nav.route, divisionPages.nav.handler)
+app.get(divisionPages.all_seasons.route, divisionPages.all_seasons.handler)
 
 app.post(divisionPages.post.route, divisionPages.post.handler)
 app.post(divisionPages.remove.route, divisionPages.remove.handler)

--- a/src/templates/division/all_seasons.pug
+++ b/src/templates/division/all_seasons.pug
@@ -1,0 +1,44 @@
+extends ../components/base.pug
+
+block title
+  title #{title} : #{division.name}
+
+block content
+  div.columns
+    div.column
+      h3.title.is-3.has-icon
+        span.icon.is-medium
+          i.fas.fa-list
+        span &nbsp;#{division.name}
+      table.table.is-striped.is-middle-aligned.is-fullwidth
+        thead
+          tr
+            th Name
+            th Players
+            th Captains
+            th Stand-ins
+            th Teams
+            th Series
+            th Standings
+            th Matchups
+        tbody
+          each season in seasons
+            tr
+              td= season.name
+              td
+                a(href='/seasons/' + season.id + '/divisions/' + division.id + '/players') players
+              td
+                a(href='/seasons/' + season.id + '/divisions/' + division.id + '/captains') captains
+              td
+                a(href='/seasons/' + season.id + '/divisions/' + division.id + '/stand-ins') stand-ins
+              td
+                a(href='/seasons/' + season.id + '/divisions/' + division.id + '/teams') teams
+              td
+                a(href='/seasons/' + season.id + '/divisions/' + division.id + '/series') series
+              td
+                a(href='/seasons/' + season.id + '/divisions/' + division.id + '/standings') standings
+              td
+                a(href='/seasons/' + season.id + '/divisions/' + division.id + '/matchups') matchups
+      if user && user.isAdmin
+        a(href='/divisions/' + division.id + '/edit')
+          button.button.is-primary Edit division

--- a/src/templates/division/division.pug
+++ b/src/templates/division/division.pug
@@ -16,12 +16,12 @@ block content
         strong Start Time
         p
           span &nbsp;#{division.start_time}
-        br
       if division.discord_url
-        strong Discord Link
+        strong Discord URL
         p
-          a(href=division.discord_url) Discord URL
-        br
+          a(href='https://discord.gg/' + division.discord_url) Invite Link
+      p
+        span &nbsp;
       h4.title
         span Active Season
       table.table.is-striped.is-middle-aligned.is-fullwidth
@@ -54,8 +54,8 @@ block content
               a(href='/seasons/' + seasons.id + '/divisions/' + division.id + '/matchups') matchups
       a(href='/divisions/' + division.id + '/all_seasons')
         button.button.is-primary View All Seasons
-      br
-      br
+      |
+      |
       if user && user.isAdmin
         a(href='/divisions/' + division.id + '/edit')
           button.button.is-primary Edit division

--- a/src/templates/division/division.pug
+++ b/src/templates/division/division.pug
@@ -10,18 +10,17 @@ block content
         span.icon.is-medium
           i.fas.fa-list
         span &nbsp;#{division.name}
-      h4.title
-        span Useful Information
-      if division.start_time
-        strong Start Time
-        p
-          span &nbsp;#{division.start_time}
-      if division.discord_url
-        strong Discord URL
-        p
-          a(href='https://discord.gg/' + division.discord_url) Invite Link
-      p
-        span &nbsp;
+      if division.start_time || division.discord_url
+        h4.title
+          span Useful Information
+        if division.start_time
+          strong Start Time
+          p
+            span &nbsp;#{division.start_time}
+        if division.discord_url
+          strong Discord URL
+          p
+            a(href='https://discord.gg/' + division.discord_url) Invite Link
       h4.title
         span Active Season
       table.table.is-striped.is-middle-aligned.is-fullwidth
@@ -52,10 +51,11 @@ block content
               a(href='/seasons/' + seasons.id + '/divisions/' + division.id + '/standings') standings
             td
               a(href='/seasons/' + seasons.id + '/divisions/' + division.id + '/matchups') matchups
-      a(href='/divisions/' + division.id + '/all_seasons')
-        button.button.is-primary View All Seasons
-      |
-      |
-      if user && user.isAdmin
-        a(href='/divisions/' + division.id + '/edit')
-          button.button.is-primary Edit division
+          div.field.is-grouped
+            p.control
+      div.field.is-grouped
+        div.control
+          a.button.is-primary(href='/divisions/' + division.id + '/all_seasons') View All Seasons
+        if user && user.isAdmin
+          div.control
+            a.button(href='/divisions/' + division.id + '/edit') Edit division

--- a/src/templates/division/division.pug
+++ b/src/templates/division/division.pug
@@ -10,10 +10,23 @@ block content
         span.icon.is-medium
           i.fas.fa-list
         span &nbsp;#{division.name}
+      h4.title
+        span Useful Information
+      if division.start_time
+        strong Start Time
+        p
+          span &nbsp;#{division.start_time}
+        br
+      if division.discord_url
+        strong Discord Link
+        p
+          a(href=division.discord_url) Discord URL
+        br
+      h4.title
+        span Active Season
       table.table.is-striped.is-middle-aligned.is-fullwidth
         thead
           tr
-            th Number
             th Name
             th Players
             th Captains
@@ -23,24 +36,26 @@ block content
             th Standings
             th Matchups
         tbody
-          each season in seasons
-            tr
-              td= season.number
-              td= season.name
-              td
-                a(href='/seasons/' + season.id + '/divisions/' + division.id + '/players') players
-              td
-                a(href='/seasons/' + season.id + '/divisions/' + division.id + '/captains') captains
-              td
-                a(href='/seasons/' + season.id + '/divisions/' + division.id + '/stand-ins') stand-ins
-              td
-                a(href='/seasons/' + season.id + '/divisions/' + division.id + '/teams') teams
-              td
-                a(href='/seasons/' + season.id + '/divisions/' + division.id + '/series') series
-              td
-                a(href='/seasons/' + season.id + '/divisions/' + division.id + '/standings') standings
-              td
-                a(href='/seasons/' + season.id + '/divisions/' + division.id + '/matchups') matchups
+          tr
+            td= seasons.name
+            td
+              a(href='/seasons/' + seasons.id + '/divisions/' + division.id + '/players') players
+            td
+              a(href='/seasons/' + seasons.id + '/divisions/' + division.id + '/captains') captains
+            td
+              a(href='/seasons/' + seasons.id + '/divisions/' + division.id + '/stand-ins') stand-ins
+            td
+              a(href='/seasons/' + seasons.id + '/divisions/' + division.id + '/teams') teams
+            td
+              a(href='/seasons/' + seasons.id + '/divisions/' + division.id + '/series') series
+            td
+              a(href='/seasons/' + seasons.id + '/divisions/' + division.id + '/standings') standings
+            td
+              a(href='/seasons/' + seasons.id + '/divisions/' + division.id + '/matchups') matchups
+      a(href='/divisions/' + division.id + '/all_seasons')
+        button.button.is-primary View All Seasons
+      br
+      br
       if user && user.isAdmin
         a(href='/divisions/' + division.id + '/edit')
           button.button.is-primary Edit division

--- a/src/templates/player/list.pug
+++ b/src/templates/player/list.pug
@@ -1,20 +1,20 @@
 extends ../components/base.pug
 
 mixin buttons
-  if user && user.isAdmin
-    div.columns
-      div.column
-        div.field.is-grouped
+  div.columns
+    div.column
+      div.field.is-grouped
+        div.control
+          a.button.is-primary(href='/seasons/' + season.id + '/divisions/' + division.id + '/draftsheet') Get draft sheet
+        if user && user.isAdmin
           div.control
-            a.button.is-primary(href='/seasons/' + season.id + '/divisions/' + division.id + '/players/create') Add player
-          div.control
-            a.button(href='/seasons/' + season.id + '/divisions/' + division.id + '/draftsheet') Get draft sheet
-          div.control
-            a.button(disabled) View players
-          div.control
-            a.button(href='/seasons/' + season.id + '/divisions/' + division.id + '/captains') View captains
-          div.control
-            a.button(href='/seasons/' + season.id + '/divisions/' + division.id + '/stand-ins') View stand-ins
+            a.button(href='/seasons/' + season.id + '/divisions/' + division.id + '/players/create') Add player
+        div.control
+          a.button(disabled) View players
+        div.control
+          a.button(href='/seasons/' + season.id + '/divisions/' + division.id + '/captains') View captains
+        div.control
+          a.button(href='/seasons/' + season.id + '/divisions/' + division.id + '/stand-ins') View stand-ins
 
 block title
   title #{title} : #{season ? season.name : ''} #{division ? division.name : '' } Players


### PR DESCRIPTION
Added the beginnings of a better experience viewing divisions. Clicking 'view' on division will take you to the Division Hub. On this page you will see the start time and discord url (if set for the division) and the current active season. At the bottom of the page is a button used to view all of the seasons (the current 'view' season page). Also removed Season Number on both pages, as it seemed unnecessary

Future plans for the page include adding a 'Division Admins' once we flesh out admins a little better and maybe an admin note.

NOTE: this PR is dependent on #8 to include references to discord_url and start_time

![](https://i.imgur.com/w5SdHDi.png)
