### PR TITLE
close old registrations

### DIFF
--- a/src/templates/season/list.pug
+++ b/src/templates/season/list.pug
@@ -24,7 +24,10 @@ block content
               td= season.number
               td= season.name
               td
-                a(href='/seasons/' + season.id + '/register') register
+                if season.registration_open
+                  a(href='/seasons/' + season.id + '/register') register
+                else
+                  span &nbsp;Closed
               if user && user.isAdmin
                 td
                   a(href='/seasons/' + season.id + '/edit') edit


### PR DESCRIPTION
If signups are closed, replace the link with a 'Closed' message