### PR TITLE
added content security policy and referrer policy

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -112,6 +112,17 @@ app.use(cookieParser(config.server.secret))
 app.use(helmet({
   frameguard: {
     action: 'deny'
+  },
+  referrerPolicy: {
+    policy: 'strict-origin-when-cross-origin'
+  },
+  contentSecurityPolicy: {
+    directives: {
+      defaultSrc: ["'self'"],
+      scriptSrc: ["'self'", "'unsafe-inline'", "use.fontawesome.com"],
+      styleSrc: ["'self'", "'unsafe-inline'", "cdnjs.cloudflare.com", "use.fontawesome.com"],
+      imgSrc: ["'self'", "cdn.discordapp.com", "steamcdn-a.akamaihd.net", "i.imgur.com"]
+    }
   }
 }))
 app.use(csrfMiddleware)

--- a/src/templates/team/edit.pug
+++ b/src/templates/team/edit.pug
@@ -24,7 +24,7 @@ block content
           div.field
             label.label(for='logo') Logo:
             p.control
-              input.input(id='logo' type='url' name='logo' placeholder='Logo' value=(team ? team.logo : ''))
+              input.input(id='logo' type='url' name='logo' placeholder='Imgur URL' value=(team ? team.logo : ''))
           div.field
             label.label(for='team_number') Team Number:
             p.control


### PR DESCRIPTION
team logos with this can only be from imgur, discord, or steam.

Things to check:
- This worked when I signed in with an account that did not have an authenticator, might need to check signins with an authenticator account, since I can't locally

Notes:
- Registrations are working, Badge fetching still working
