### PR TITLE
Steam names on player profile pages now click-able

### DIFF
--- a/src/templates/profile/view.pug
+++ b/src/templates/profile/view.pug
@@ -55,7 +55,8 @@ block content
       article.tile.is-child.notification
         div.content
           p.title Steam Name
-          p.subtitle= profile.steam_name
+          p.subtitle
+            a(href='https://steamcommunity.com/profiles/' + profile.id64) profile.steam_name
         div.content
           p.title RD2L Name
           p.subtitle= profile.name
@@ -80,9 +81,6 @@ block content
         div.content
           p.title Resources
           ul
-            li
-              a(href='https://steamcommunity.com/profiles/' + profile.id64)
-                span Steam
             li
               a(href='https://www.dotabuff.com/players/' + profile.steam_id)
                 span Dotabuff


### PR DESCRIPTION
I _think_ this'll make player profiles click-able. Didn't test it because I'm lazy, but it's a pretty simple change so it should be easy to verify.