### PR TITLE
Make Team Name show as "Team Name (Captain Name)"

### DIFF
--- a/src/pages/series.js
+++ b/src/pages/series.js
@@ -26,10 +26,10 @@ function list(templates, season, series, division, req, res) {
           if (_series.away_team_id) {
             _series.away = {}
             _series.away.id = _series.away_team_id
-            if (_series.home_team_name != _series.home_team_captain_name) {
-              _series.home.name = `${_series.home_team_name} (${_series.home_team_captain_name})`
+            if (_series.away_team_name != _series.away_team_captain_name) {
+              _series.away.name = `${_series.away_team_name} (${_series.away_team_captain_name})`
             } else {
-              _series.home.name = _series.home_team_captain_name
+              _series.away.name = _series.away_team_captain_name
             }
             _series.away.name = _series.away_team_name
             _series.away.logo = _series.away_team_logo

--- a/src/pages/series.js
+++ b/src/pages/series.js
@@ -15,13 +15,22 @@ function list(templates, season, series, division, req, res) {
           if (_series.home_team_id) {
             _series.home = {}
             _series.home.id = _series.home_team_id
-            _series.home.name = _series.home_team_name
+            if (_series.home_team_name != _series.home_team_captain_name) {
+              _series.home.name = `${_series.home_team_name} (${_series.home_team_captain_name})`
+            } else {
+              _series.home.name = _series.home_team_captain_name
+            }
             _series.home.logo = _series.home_team_logo
             _series.home.points = _series.home_points
           }
           if (_series.away_team_id) {
             _series.away = {}
             _series.away.id = _series.away_team_id
+            if (_series.home_team_name != _series.home_team_captain_name) {
+              _series.home.name = `${_series.home_team_name} (${_series.home_team_captain_name})`
+            } else {
+              _series.home.name = _series.home_team_captain_name
+            }
             _series.away.name = _series.away_team_name
             _series.away.logo = _series.away_team_logo
             _series.away.points = _series.away_points


### PR DESCRIPTION
relies on implementation detail that in the database the default team name is the captain's name. I've seen that to be true, but I'm not sure if it's something that will always stay true.

An alternative would be to check for substring match rather than exact match with something like `_series.home_team_name.indexOf(_series.home_team_captain_name) !== -1`. There may also be some flag I don't know about in the data for if the team has been named.