### PR TITLE
Mobile-friendly update for main page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 node_modules
 .env
 .idea
+.vscode
+.project
+*.sublime-*

--- a/src/templates/components/base.pug
+++ b/src/templates/components/base.pug
@@ -20,6 +20,25 @@ html(lang='en')
         link(rel='icon' type='image/png' href='/assets/notext.png')
         script(defer src='https://use.fontawesome.com/releases/v5.0.9/js/all.js' integrity='sha384-8iPTk2s/jMVj81dnzb/iFR2sdA7u06vHJyyLlAd4snFpCl/SnyUjRrbdJsw1pGIl' crossorigin='anonymous')
         style(type='text/css').
+          .logo-container {
+            width: auto;
+            margin: 1.5rem auto 0;
+            text-align: center;
+          }
+          figure.littlelogo {
+            visibility: hidden;
+            display: none;
+          }
+          @media(max-width: 520px) {
+            figure.biglogo {
+              visibility: hidden;
+              display: none;
+            }
+            figure.littlelogo {
+              visibility: visible;
+              display: block;
+            }
+          }
           .disbanded {
             text-decoration: line-through;
           }

--- a/src/templates/index.pug
+++ b/src/templates/index.pug
@@ -4,12 +4,11 @@ block title
   title RD2L: Reddit Dota 2 League
 
 block append header
-  div.hero-body.has-text-centered
-    div.container
-      div.columns
-        div.column
-          figure.image.is-hero.hide-overflow.is-inline-block
-            img(src='/assets/rd2l-lame.png')
+  div.logo-container
+    figure.biglogo
+      img(src="/assets/rd2l-lame.png")
+    figure.littlelogo
+      img(src="/assets/notext.png")
 
 block contentFull
   section.section


### PR DESCRIPTION
On screens that are too small to properly display the big logo on the main landing page, the smaller "notext" image is used instead.