### PR TITLE
Fix to display away captain names

### DIFF
--- a/src/pages/series.js
+++ b/src/pages/series.js
@@ -31,7 +31,6 @@ function list(templates, season, series, division, req, res) {
             } else {
               _series.away.name = _series.away_team_captain_name
             }
-            _series.away.name = _series.away_team_name
             _series.away.logo = _series.away_team_logo
             _series.away.points = _series.away_points
           }


### PR DESCRIPTION
Removed line 34 in pre-existing code to display captain name in series tab properly.