### PR TITLE
fix(csrf): add required getSessionIdentifier and fix middleware order

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -123,6 +123,7 @@ const app = express()
 
 const { generateCsrfToken, doubleCsrfProtection } = doubleCsrf({
   getSecret: () => config.server.secret,
+  getSessionIdentifier: (req) => req.session.id,
   cookieName: '_csrf',
   cookieOptions: {
     httpOnly: true,
@@ -161,11 +162,6 @@ app.set('trust proxy', true)
 app.use(bodyParser.json())
 app.use(bodyParser.urlencoded({ extended: true }))
 app.use(cookieParser(config.server.secret))
-app.use(doubleCsrfProtection)
-app.use((req, res, next) => {
-  req.csrfToken = () => generateCsrfToken(req, res)
-  next()
-})
 app.use(session({
   store: new PGStore({
     pool: pool,
@@ -179,6 +175,11 @@ app.use(session({
   resave: true,
   saveUninitialized: true
 }))
+app.use(doubleCsrfProtection)
+app.use((req, res, next) => {
+  req.csrfToken = () => generateCsrfToken(req, res)
+  next()
+})
 app.use(passport.initialize())
 app.use(passport.session())
 app.use((req, _, next) => {


### PR DESCRIPTION
csrf-csrf v4 requires getSessionIdentifier as a mandatory option. Also move session middleware before doubleCsrfProtection so req.session is available when CSRF token generation runs.

https://claude.ai/code/session_01PTGTsebQPrivZ6HoKGcKbL