### PR TITLE
Remove nested condition check in user creation logic

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -30,12 +30,10 @@ async function createUser(
     existingUser = null
   }
 
-  if (!existingUser) {
-    const admins = await admin.getAdmins()
-    if (admins.length === 0) {
-      await admin.saveAdmin({ steam_id: id, group_id: '_' })
-      console.log('Created first admin')
-    }
+  const admins = await admin.getAdmins()
+  if (admins.length === 0) {
+    await admin.saveAdmin({ steam_id: id, group_id: '_' })
+    console.log('Created first admin')
   }
 
   const user: SteamUser = {


### PR DESCRIPTION
## Summary
Simplified the user creation logic by removing an unnecessary nested conditional check that was preventing the first admin from being created in certain scenarios.

## Key Changes
- Removed the `if (!existingUser)` wrapper condition around the admin initialization logic
- The admin check and creation now executes unconditionally during user creation
- This ensures the first admin is created regardless of whether an existing user was found

## Implementation Details
The original code only attempted to create the first admin if no existing user was found. By removing this nesting, the admin initialization logic now runs every time `createUser` is called, which is the correct behavior since we want to ensure at least one admin exists in the system. The `admins.length === 0` check still prevents duplicate admin creation.

https://claude.ai/code/session_01NEM4zimc4t9uD65MejZsQQ