### PR TITLE
docs: reorganize documentation and simplify development setup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,18 +2,14 @@
 
 This file provides guidance for Claude when working in this repository.
 
-## Project Overview
+@README.md
+@CONTRIBUTING.md
 
-RD2L server — a Node.js + TypeScript backend and website for a competitive gaming league. It uses Express.js, Pug templates, and PostgreSQL.
-
-## Development Commands
+## Development commands
 
 ```bash
 # Install dependencies
 npm ci
-
-# Run in development (hot reload via nodemon + ts-node)
-npm run dev
 
 # Type-check and lint (used as the test suite in CI)
 npm test
@@ -24,116 +20,33 @@ npm run build
 # Start compiled server
 npm start
 
-# Apply database migrations
+# Apply database migrations (requires a built dist/)
 npm run migrate
 
-# Seed database with development data (idempotent)
+# Seed database with development data (idempotent, requires a built dist/)
 npm run seed
-
-# Build Docker image
-npm run docker
 ```
-
-## Environment Setup
-
-Copy `.env.example` (if present) or provide the following environment variables:
-
-| Variable | Description |
-|---|---|
-| `STEAM_API_KEY` | Steam Web API key |
-| `DATABASE_URL` | PostgreSQL connection string |
-| `SESSION_SECRET` | Express session secret |
-| `SSL_CERT` / `SSL_KEY` | TLS certificate paths (production) |
-
-Do **not** access `process.env` directly in source files — it is forbidden by ESLint (`no-process-env`). Read env vars in a dedicated config module and import from there.
 
 ## Architecture
 
 ```
 src/
-  server.ts          # Entry point — Express app setup, middleware, route mounting
-  migrate-cli.ts     # CLI runner for database migrations
-  seed-cli.ts        # CLI runner for seed data
-  migrations/        # Ordered SQL migration files (applied by filename)
-  routes/            # Express routers, one file per feature area
-  views/             # Pug templates
-  public/            # Static assets
+  api/           # JSON API controllers
+  assets/        # Static files (images, markdown, JSON)
+  lib/           # Shared utilities
+  migrations/    # Ordered SQL migration files (applied by filename)
+  pages/         # Page controllers (HTML endpoints)
+  repos/         # Database access layer
+  templates/     # Pug templates
+  types/         # TypeScript type definitions
+  config.ts      # Environment variable configuration — the only place process.env is read
+  migrate-cli.ts # CLI runner for database migrations
+  seed-cli.ts    # CLI runner for seed data
+  seed-data.ts   # Seed data definitions
+  server.ts      # Entry point — Express app setup, middleware, route mounting
 ```
 
 - **Database**: PostgreSQL accessed via `pg` and `pg-sql`. Migrations are plain SQL files run in alphabetical/numeric filename order.
 - **Auth**: Steam OpenID via `passport-steam`. Sessions stored in PostgreSQL with `connect-pg-simple`.
 - **Rendering**: Server-side HTML with Pug. No client-side framework.
-
-## Code Style
-
-Enforced by ESLint (`eslint.config.cjs`) and TypeScript strict mode:
-
-- **Quotes**: single quotes
-- **Semicolons**: none
-- **Indent**: 2 spaces
-- **Max line length**: 250 characters
-- **Variables**: `const` preferred; `var` forbidden
-- **Unused vars**: allowed only when prefixed with `_`
-- **`any` type**: warned against — avoid where possible
-- **`process.env`**: forbidden in source — use a config module
-
-Run `npm test` to check types and lint before committing.
-
-## Database Migrations
-
-Add a new SQL file under `src/migrations/` using a name that sorts after all existing files (e.g. `030_add_column.sql`). Migrations run once in order and are tracked to avoid re-execution.
-
-## Commit Style
-
-This project uses **Conventional Commits** (https://www.conventionalcommits.org/en/v1.0.0/).
-
-### Format
-
-```
-<type>(<optional scope>): <short description>
-
-[optional body]
-
-[optional footer(s)]
-```
-
-### Types
-
-| Type | When to use |
-|---|---|
-| `feat` | A new feature |
-| `fix` | A bug fix |
-| `docs` | Documentation changes only |
-| `style` | Formatting, whitespace — no logic change |
-| `refactor` | Code change that is neither a fix nor a feature |
-| `perf` | Performance improvement |
-| `test` | Adding or updating tests/linting |
-| `build` | Build system or dependency changes |
-| `ci` | CI/CD configuration changes |
-| `chore` | Maintenance tasks that don't fit above |
-| `revert` | Reverts a previous commit |
-
-### Rules
-
-- Use the **imperative mood** in the short description: "add feature" not "added feature"
-- Keep the first line at or under **72 characters**
-- Reference GitHub issues in the footer: `Closes #123`
-- Mark breaking changes with `!` after the type/scope or a `BREAKING CHANGE:` footer
-
-### Examples
-
-```
-feat(auth): add Steam login support
-
-fix(pairing): correct blossom algorithm edge case for odd player count
-
-docs: add CLAUDE.md with development and commit guidelines
-
-build(deps): bump express from 5.0.0 to 5.1.0
-
-ci: add railway validation workflow
-
-feat!: drop support for Node 18
-
-BREAKING CHANGE: minimum Node.js version is now 20
-```
+- **Config**: All environment variables are read in `src/config.ts`. Do not access `process.env` anywhere else — it is forbidden by ESLint (`no-process-env`).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,77 @@
+# Contributing
+
+## Code style
+
+Enforced by ESLint (`eslint.config.cjs`) and TypeScript strict mode:
+
+- **Quotes**: single quotes
+- **Semicolons**: none
+- **Indent**: 2 spaces
+- **Max line length**: 250 characters
+- **Variables**: `const` preferred; `var` forbidden
+- **Unused vars**: allowed only when prefixed with `_`
+- **`any` type**: warned against — avoid where possible
+- **`process.env`**: forbidden in source — use `src/config.ts`
+
+Run `npm test` to check types and lint before committing.
+
+## Adding database migrations
+
+Add a new SQL file under `src/migrations/` using a name that sorts after all
+existing files (e.g. `030_add_column.sql`). Migrations run once in order and
+are tracked to avoid re-execution.
+
+## Commit style
+
+This project uses [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
+
+### Format
+
+```
+<type>(<optional scope>): <short description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+### Types
+
+| Type | When to use |
+|---|---|
+| `feat` | A new feature |
+| `fix` | A bug fix |
+| `docs` | Documentation changes only |
+| `style` | Formatting, whitespace — no logic change |
+| `refactor` | Code change that is neither a fix nor a feature |
+| `perf` | Performance improvement |
+| `test` | Adding or updating tests/linting |
+| `build` | Build system or dependency changes |
+| `ci` | CI/CD configuration changes |
+| `chore` | Maintenance tasks that don't fit above |
+| `revert` | Reverts a previous commit |
+
+### Rules
+
+- Use the **imperative mood** in the short description: "add feature" not "added feature"
+- Keep the first line at or under **72 characters**
+- Reference GitHub issues in the footer: `Closes #123`
+- Mark breaking changes with `!` after the type/scope or a `BREAKING CHANGE:` footer
+
+### Examples
+
+```
+feat(auth): add Steam login support
+
+fix(pairing): correct blossom algorithm edge case for odd player count
+
+docs: add CLAUDE.md with development and commit guidelines
+
+build(deps): bump express from 5.0.0 to 5.1.0
+
+ci: add railway validation workflow
+
+feat!: drop support for Node 18
+
+BREAKING CHANGE: minimum Node.js version is now 20
+```

--- a/README.md
+++ b/README.md
@@ -5,86 +5,77 @@
 [![Checks status](https://img.shields.io/github/checks-status/hardytool/server/trunk?logo=railway&label=deploy)](https://github.com/hardytool/server/commit/trunk)
 [![Uptime Robot status](https://img.shields.io/uptimerobot/status/m787441842-04cf73902b7c489f45837dd0?logo=railway)](https://stats.uptimerobot.com/4zOmnCzkKJ)
 
-This is RD2L's backend and website.
+RD2L's backend and website — a Node.js + TypeScript server built with Express.js, Pug templates, and PostgreSQL.
 
 ## Installation
 
-First, install the project's dependencies.
+Install dependencies:
 
 ```sh
-npm install
+npm ci
 ```
 
-Next, get an api key from <https://steamcommunity.com/dev/apikey>. Either set this
-as an environment variable or a variable in a `.env` file - name must be
-`STEAM_API_KEY`.
+## Environment
 
-Here's a template with example values for a complete `.env` file:
+Copy `.env.example` or create a `.env` file with the following variables:
 
 ```bash
+# Required
+STEAM_API_KEY='get from https://steamcommunity.com/dev/apikey'
+SECRET='random characters'
+
+# Database (individual connection parameters)
 POSTGRES_USER='postgres'
 POSTGRES_PASSWORD='postgres'
 POSTGRES_DB='seal'
 POSTGRES_HOST='localhost'
 POSTGRES_PORT='5432'
+
+# Server
 PORT='80'
 HTTPS_PORT='443'
-SECRET='random characters'
-STEAM_API_KEY='get from https://steamcommunity.com/dev/apikey'
+HOST='localhost'
 ```
 
-For HTTPS configuration, include the following entries:
+Optional variables:
 
 ```bash
-SSL_KEY='path/to/key.pem'
-SSL_CERT='path/to/cert.pem'
-SSL_CA='path/to/ca.pem'
-```
-
-Auth requests can be forwarded by providing:
-
-```bash
+# Forward auth return requests to a different URL
 WEBSITE_URL='http://return-to-website.com'
-```
 
-Full database configuration can be configured using:
-
-```bash
-POSTGRES_USER='postgres'
-POSTGRES_PASSWORD='postgres'
-POSTGRES_DB='seal'
-POSTGRES_HOST='localhost'
-POSTGRES_PORT='5432'
+# Database connection tuning
 POSTGRES_POOL_MAX='10'
 POSTGRES_TIMEOUT='30000'
+POSTGRES_SSL='true'
 ```
+
+> **Note:** Do not access `process.env` directly in source files — it is forbidden by ESLint. Read env vars in `src/config.ts` and import from there.
 
 ## Running
 
-To run locally:
+Build the TypeScript source, then start the server:
 
 ```sh
+npm run build
 npm start
 ```
 
-To run in docker:
+To run with Docker Compose (automatically handles migrations and seeds):
 
 ```sh
 make build
 make run
 ```
 
-Running in docker requires environment variables, not .env variables.
-Additionally, and unsurprisingly, it requires docker to be installed and
-running.
+`make run` requires `STEAM_API_KEY` and `SECRET` to be set in the environment. Running with Docker Compose does not use `.env` files — pass environment variables directly.
 
 ## Database migrations
 
 Migrations are SQL files in `src/migrations/` and run in filename order
 (e.g. `001.sql` before `002.sql`). They are applied automatically on startup
-when running via docker compose.
+when running via Docker Compose.
 
-To run migrations manually:
+To run migrations manually (after building):
 
 ```sh
 npm run migrate
@@ -96,7 +87,7 @@ Seed data populates the database with sample content for local development and
 testing. It includes seasons, divisions, teams, and users. Seeding is
 idempotent — running it multiple times is safe and will not create duplicates.
 
-When using docker compose, seeds are applied automatically after migrations on
+When using Docker Compose, seeds are applied automatically after migrations on
 every `docker compose up`.
 
 To run seeds manually (after building):
@@ -107,28 +98,28 @@ npm run seed
 
 ## Project structure
 
-```bash
-├── src
-│   ├── api
-│   │   └── *.ts       # API-oriented controllers
-│   ├── assets
-│   │   └── **/*       # Static files (including images, markdown, etc.)
-│   ├── lib
-│   │   └── *.ts       # Common utilities/shared libraries
-│   ├── migrations
-│   │   └── *.sql      # Database migration files applied in order (001.sql first)
-│   ├── seed-data.ts   # Seed data definitions (seasons, divisions, teams, users)
-│   ├── seed-cli.ts    # Standalone CLI entry point for running seeds
-│   ├── migrate-cli.ts # Standalone CLI entry point for running migrations
-│   ├── pages
-│   │   └── *.ts       # Page content controllers
-│   ├── repos
-│   │   └── *.ts       # Database model repositories
-│   ├── templates
-│   │   └── **/*.pug   # Template files structured as a hierarchical tree
-├── Dockerfile
-├── docker-compose.yml # Development-oriented quickstart compose file
-├── Makefile           # Command wrapper
-├── package.json
-└── package-lock.json
 ```
+src/
+  api/           # JSON API controllers
+  assets/        # Static files (images, markdown, JSON)
+  lib/           # Shared utilities
+  migrations/    # SQL migration files applied in order
+  pages/         # Page controllers (HTML endpoints)
+  repos/         # Database access layer
+  templates/     # Pug templates
+  types/         # TypeScript type definitions
+  config.ts      # Environment variable configuration
+  migrate-cli.ts # CLI entry point for migrations
+  seed-cli.ts    # CLI entry point for seeding
+  seed-data.ts   # Seed data definitions
+  server.ts      # Application entry point
+Dockerfile
+docker-compose.yml  # Development-oriented quickstart compose file
+Makefile            # Docker Compose wrapper
+package.json
+package-lock.json
+```
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for code style, commit conventions, and how to add database migrations.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ npm ci
 
 ## Environment
 
-Copy `.env.example` or create a `.env` file with the following variables:
+Create a `.env` file with the following variables:
 
 ```bash
 # Required
@@ -67,7 +67,7 @@ make build
 make run
 ```
 
-`make run` requires `STEAM_API_KEY` and `SECRET` to be set in the environment. Running with Docker Compose does not use `.env` files — pass environment variables directly.
+`make run` requires `STEAM_API_KEY` and `SECRET` to be set. Docker Compose reads `.env` automatically, so you can use the same file for both local and Compose workflows.
 
 ## Database migrations
 

--- a/package.json
+++ b/package.json
@@ -6,11 +6,9 @@
   "scripts": {
     "test": "tsc --noEmit && eslint src",
     "start": "node dist/server.js",
-    "dev": "nodemon --exec 'ts-node src/server.ts' -e pug,ts",
     "build": "tsc",
     "migrate": "node dist/migrate-cli.js",
-    "seed": "node dist/seed-cli.js",
-    "docker": "docker build -t rd2l/server ."
+    "seed": "node dist/seed-cli.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Reorganized project documentation to improve clarity and maintainability by extracting contribution guidelines into a dedicated file and streamlining the main README and CLAUDE.md files.

## Key Changes

- **Created `CONTRIBUTING.md`**: Extracted code style, commit conventions, and database migration guidelines from CLAUDE.md into a new dedicated contribution guide
- **Simplified `CLAUDE.md`**: Reduced to essential developer reference with links to README.md and CONTRIBUTING.md, keeping only architecture overview and development commands
- **Improved `README.md`**: 
  - Clarified environment variable setup with better organization (required vs optional)
  - Simplified installation and running instructions
  - Updated project structure diagram for readability
  - Added link to CONTRIBUTING.md for detailed guidelines
  - Improved Docker Compose documentation
- **Removed development scripts from `package.json`**:
  - Removed `npm run dev` (nodemon + ts-node) — users should build and run with `npm start`
  - Removed `npm run docker` — Docker builds are handled via Makefile

## Notable Details

- All three documentation files now have clear, complementary purposes: README for setup/running, CLAUDE.md for quick developer reference, CONTRIBUTING.md for code standards
- Environment variable documentation is now more structured and easier to scan
- Development workflow is simplified: build first with `npm run build`, then run with `npm start`
- No functional code changes — purely documentation and build script reorganization

https://claude.ai/code/session_019Z1srmZAjRb8ciqi1nAsJs