### PR TITLE
docs: clarify PR titles must follow conventional commit format

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,6 +57,7 @@ This project uses [Conventional Commits](https://www.conventionalcommits.org/en/
 - Keep the first line at or under **72 characters**
 - Reference GitHub issues in the footer: `Closes #123`
 - Mark breaking changes with `!` after the type/scope or a `BREAKING CHANGE:` footer
+- **PR titles** must also follow the conventional commit format — they are used as the squash merge commit message
 
 ### Examples
 


### PR DESCRIPTION
## Summary
Updated the CONTRIBUTING.md documentation to explicitly clarify that pull request titles must follow the conventional commit format, since they are used as squash merge commit messages.

## Changes
- Added a new guideline note that PR titles must follow conventional commit format
- This ensures consistency between PR titles and the final commit messages in the repository history

## Details
This documentation update helps contributors understand that PR titles are not just for communication purposes—they directly become commit messages when PRs are squash-merged. This prevents contributors from having to revise their PR titles during the merge process and maintains a clean, consistent commit history.

https://claude.ai/code/session_01JDW5STgZjVmLd4JffCUc8R