### PR TITLE
Handle BYE rounds in series list template

### DIFF
--- a/src/templates/series/list.pug
+++ b/src/templates/series/list.pug
@@ -72,12 +72,17 @@ block content
         each _series in series
           tr
             td= _series.round
-            td
-              a(href='/seasons/' + season.id + '/divisions/' + division.id + '/teams/' + _series.home.id)= _series.home.name
-            td
-              figure.image.is-team-logo.hide-overflow
-                img(src=_series.home.logo)
-            td= _series.home.points
+            if _series.home
+              td
+                a(href='/seasons/' + season.id + '/divisions/' + division.id + '/teams/' + _series.home.id)= _series.home.name
+              td
+                figure.image.is-team-logo.hide-overflow
+                  img(src=_series.home.logo)
+              td= _series.home.points
+            else
+              td BYE
+              td BYE
+              td 0
             if _series.away
               td= _series.away.points
               td


### PR DESCRIPTION
## Summary
Updated the series list template to gracefully handle BYE rounds where a team doesn't have a home opponent scheduled.

## Key Changes
- Added conditional check for `_series.home` existence before rendering home team details
- When home team is absent (BYE round), display "BYE" text instead of team name and logo
- Set points to 0 for BYE rounds to maintain table structure consistency

## Implementation Details
The template now wraps home team rendering (name, logo, and points) in an `if _series.home` block. When the condition is false, an `else` block displays placeholder "BYE" values across the three columns, ensuring the table layout remains intact regardless of whether a team has a scheduled opponent.

https://claude.ai/code/session_01RJDQomtDuJ8EcKADRLsn8Y