### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/tests/repos/team_player.test.ts
+++ b/tests/repos/team_player.test.ts
@@ -48,7 +48,7 @@ describe.runIf(isDockerAvailable())('team_player repo', () => {
 
   describe('getUnassignedPlayers', () => {
     it('returns only unassigned players', async () => {
-      const { s, d, pl1, pl2, t } = await setupData()
+      const { s, d, pl1, t } = await setupData()
 
       await teamPlayer.addPlayerToTeam(t.id, pl1.id, true)
 


### PR DESCRIPTION
Remove the unused `pl2` binding from the destructuring assignment in the `getUnassignedPlayers` test case.

Best fix without changing behavior:
- In `tests/repos/team_player.test.ts`, line 51 region, change:
  - `const { s, d, pl1, pl2, t } = await setupData()`
  - to `const { s, d, pl1, t } = await setupData()`
- No logic changes, no new imports, no new methods/definitions needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._