### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/tests/repos/player.test.ts
+++ b/tests/repos/player.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
 import { setupDatabase, teardownDatabase, getPool, cleanTables, isDockerAvailable } from '../helpers/db'
-import { resetIds, insertSeason, insertDivision, insertSteamUser, insertPlayer, insertTeam, insertTeamPlayer, insertProfile } from '../helpers/fixtures'
+import { resetIds, insertSeason, insertDivision, insertSteamUser, insertPlayer } from '../helpers/fixtures'
 import playerRepo from '../../src/repos/player'
 
 describe.runIf(isDockerAvailable())('player repo', () => {


### PR DESCRIPTION
To fix this without changing functionality, remove the three unused named imports from the fixtures import line in `tests/repos/player.test.ts`.

Best single fix:
- Edit the import on line 3.
- Keep all currently used helpers (`resetIds`, `insertSeason`, `insertDivision`, `insertSteamUser`, `insertPlayer`).
- Remove only `insertTeam`, `insertTeamPlayer`, and `insertProfile`.

No new methods, definitions, or external dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._